### PR TITLE
add new OpenMP alpaka kernel

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2015 Benjamin Worpitz
+# Copyright 2014-2015 Benjamin Worpitz, Rene Widera
 #
 # This file is part of matmul.
 #
@@ -83,6 +83,15 @@ UNSET(_MATMUL_BENCHMARK_LINK_FLAGS)
 #-------------------------------------------------------------------------------
 # Options.
 #-------------------------------------------------------------------------------
+
+SET(MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL ON CACHE BOOL "Use the CUDA SDK kernel if alapka is used")
+IF(MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL)
+    LIST(APPEND _MATMUL_BENCHMARK_COMPILE_DEFINITIONS "MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL")
+ENDIF()
+SET(MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL ON CACHE BOOL "Use the OpenMP2 kernel if alapka is used")
+IF(MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL)
+    LIST(APPEND _MATMUL_BENCHMARK_COMPILE_DEFINITIONS "MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL")
+ENDIF()
 
 SET(MATMUL_BENCHMARK_SEQ_BASIC OFF CACHE BOOL "Enable the basic sequential GEMM")
 IF(MATMUL_BENCHMARK_SEQ_BASIC)

--- a/benchmark/src/main.c
+++ b/benchmark/src/main.c
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 //! \file
-//! Copyright 2013-2015 Benjamin Worpitz
+//! Copyright 2013-2015 Benjamin Worpitz, Rene Widera
 //!
 //! This file is part of matmul.
 //!
@@ -628,25 +628,60 @@ int main(
         {matmul_gemm_par_openacc_parallel, "gemm_par_openacc_parallel", 3.0},
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_CPU_B_OMP2_T_SEQ
-        {matmul_gemm_par_alpaka_cpu_b_omp2_t_seq, "gemm_par_alpaka_cpu_b_omp2_t_seq", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_par_alpaka_cpu_b_omp2_t_seq, "gemm_par_alpaka_cpu_b_omp2_t_seq", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_par_alpaka_cpu_b_omp2_t_seq_ompNative, "gemm_par_alpaka_cpu_b_omp2_t_seq_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_CPU_B_SEQ_T_OMP2
-        {matmul_gemm_par_alpaka_cpu_b_seq_t_omp2, "gemm_par_alpaka_cpu_b_seq_t_omp2", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_par_alpaka_cpu_b_seq_t_omp2, "gemm_par_alpaka_cpu_b_seq_t_omp2", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_par_alpaka_cpu_b_seq_t_omp2_ompNative, "gemm_par_alpaka_cpu_b_seq_t_omp2_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_CPU_BT_OMP4
-        {matmul_gemm_par_alpaka_cpu_bt_omp4, "gemm_par_alpaka_cpu_bt_omp4", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_par_alpaka_cpu_bt_omp4, "gemm_par_alpaka_cpu_bt_omp4", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_par_alpaka_cpu_bt_omp4_ompNative, "gemm_par_alpaka_cpu_bt_omp4_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_CPU_B_SEQ_T_THREADS
-        {matmul_gemm_par_alpaka_cpu_b_seq_t_threads, "gemm_par_alpaka_cpu_b_seq_t_threads", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_par_alpaka_cpu_b_seq_t_threads, "gemm_par_alpaka_cpu_b_seq_t_threads", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_par_alpaka_cpu_b_seq_t_threads_ompNative, "gemm_par_alpaka_cpu_b_seq_t_threads_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_CPU_B_SEQ_T_FIBERS
-        {matmul_gemm_seq_alpaka_cpu_b_seq_t_fibers, "gemm_seq_alpaka_cpu_b_seq_t_fibers", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_seq_alpaka_cpu_b_seq_t_fibers, "gemm_seq_alpaka_cpu_b_seq_t_fibers", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_seq_alpaka_cpu_b_seq_t_fibers_ompNative, "gemm_seq_alpaka_cpu_b_seq_t_fibers_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_CPU_B_SEQ_T_SEQ
-        {matmul_gemm_seq_alpaka_cpu_b_seq_t_seq, "gemm_seq_alpaka_cpu_b_seq_t_seq", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_seq_alpaka_cpu_b_seq_t_seq, "gemm_seq_alpaka_cpu_b_seq_t_seq", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_seq_alpaka_cpu_b_seq_t_seq_ompNative, "gemm_seq_alpaka_cpu_b_seq_t_seq_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_GPU_CUDA_MEMCPY
-        {matmul_gemm_par_alpaka_gpu_cuda_memcpy, "gemm_par_alpaka_gpu_cuda_memcpy", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_par_alpaka_gpu_cuda_memcpy, "gemm_par_alpaka_gpu_cuda_memcpy", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_par_alpaka_gpu_cuda_memcpy_ompNative, "gemm_par_alpaka_gpu_cuda_memcpy_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_CUDA_MEMCPY_FIXED_BLOCK_SIZE
         {matmul_gemm_par_cuda_memcpy_fixed_block_size_2d_static_shared, "gemm_par_cuda_memcpy_fixed_block_size_2d_static_shared", 3.0},
@@ -667,7 +702,12 @@ int main(
     #endif
 
     #ifdef MATMUL_BENCHMARK_PAR_ALPAKA_ACC_GPU_CUDA
-        {matmul_gemm_par_alpaka_gpu_cuda, "gemm_par_alpaka_gpu_cuda", 3.0},
+        #ifdef MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL
+            {matmul_gemm_par_alpaka_gpu_cuda, "gemm_par_alpaka_gpu_cuda", 3.0},
+        #endif
+        #ifdef MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL
+            {matmul_gemm_par_alpaka_gpu_cuda_ompNative, "gemm_par_alpaka_gpu_cuda_ompNative", 3.0},
+        #endif
     #endif
     #ifdef MATMUL_BENCHMARK_PAR_CUDA_FIXED_BLOCK_SIZE
         {matmul_gemm_par_cuda_fixed_block_size_2d_static_shared, "gemm_par_cuda_fixed_block_size_2d_static_shared", 3.0},

--- a/include/matmul/matmul.h
+++ b/include/matmul/matmul.h
@@ -26,6 +26,7 @@
 #include <matmul/seq/MultipleOpts.h>
 #include <matmul/seq/Strassen.h>
 #include <matmul/par/Alpaka.h>
+#include <matmul/par/AlpakaOmpNative.h>
 #include <matmul/par/BlasCublas.h>
 #include <matmul/par/BlasMkl.h>
 #include <matmul/par/Cuda.h>

--- a/include/matmul/par/AlpakaOmpNative.h
+++ b/include/matmul/par/AlpakaOmpNative.h
@@ -1,0 +1,227 @@
+//-----------------------------------------------------------------------------
+//! \file
+//! Copyright 2013-2016 Benjamin Worpitz, Rene Widera
+//!
+//! This file is part of matmul.
+//!
+//! matmul is free software: you can redistribute it and/or modify
+//! it under the terms of the GNU Lesser General Public License as published by
+//! the Free Software Foundation, either version 3 of the License, or
+//! (at your option) any later version.
+//!
+//! matmul is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//! GNU Lesser General Public License for more details.
+//!
+//! You should have received a copy of the GNU Lesser General Public License
+//! along with matmul.
+//! If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#if defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_SEQ) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA_MEMCPY) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_OMP2_T_SEQ) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_OMP2) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_BT_OMP4) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_THREADS) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_FIBERS)
+
+    #include <matmul/common/Config.h>   // TElem, TSize, TReturn
+
+    #ifdef __cplusplus
+        extern "C"
+        {
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_SEQ
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s serial accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_seq_alpaka_cpu_b_seq_t_seq_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_OMP2_T_SEQ
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s OpenMP 2.0 block accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_b_omp2_t_seq_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_OMP2
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s OpenMP 2.0 thread accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_b_seq_t_omp2_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_BT_OMP4
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s OpenMP 4.0 accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_bt_omp4_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_THREADS
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s std::thread accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_b_seq_t_threads_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_FIBERS
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s boost::fiber accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_seq_alpaka_cpu_b_seq_t_fibers_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s CUDA accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_gpu_cuda_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA_MEMCPY
+        //-----------------------------------------------------------------------------
+        //! (S/D)GEMM matrix-matrix product C = alpha * A * B + beta * C using alpaka`s CUDA accelerator back-end.
+        //!
+        //! \param m Specifies the number of rows of the matrix A and of the matrix C.
+        //! \param n Specifies the number of columns of the matrix B and the number of columns of the matrix C.
+        //! \param k Specifies the number of columns of the matrix A and the number of rows of the matrix B.
+        //! \param alpha Scalar value used to scale the product of matrices A and B.
+        //! \param A Array, size lda-by-k. The leading m-by-k part of the array must contain the matrix A.
+        //! \param lda Specifies the leading dimension of A.
+        //! \param B Array, size ldb-by-n. The leading k-by-n part of the array must contain the matrix B.
+        //! \param ldb Specifies the leading dimension of B.
+        //! \param beta Scalar value used to scale matrix C.
+        //! \param C Array, size ldc-by-n. The leading m-by-n part of the array must contain the matrix C.
+        //! \param ldc Specifies the leading dimension of C.
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_gpu_cuda_memcpy_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc);
+    #endif
+    #ifdef __cplusplus
+        }
+    #endif
+#endif

--- a/include/matmul/par/AlpakaOmpNative.hpp
+++ b/include/matmul/par/AlpakaOmpNative.hpp
@@ -1,0 +1,339 @@
+//-----------------------------------------------------------------------------
+//! \file
+//! Copyright 2013-2016 Benjamin Worpitz, Rene Widera
+//!
+//! This file is part of matmul.
+//!
+//! matmul is free software: you can redistribute it and/or modify
+//! it under the terms of the GNU Lesser General Public License as published by
+//! the Free Software Foundation, either version 3 of the License, or
+//! (at your option) any later version.
+//!
+//! matmul is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//! GNU Lesser General Public License for more details.
+//!
+//! You should have received a copy of the GNU Lesser General Public License
+//! along with matmul.
+//! If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#if defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_SEQ) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA_MEMCPY) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_OMP2_T_SEQ) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_OMP2) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_BT_OMP4) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_THREADS) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_FIBERS)
+
+    #include <matmul/common/Mat.h>  // matmul_mat_gemm_early_out
+
+    #include <alpaka/alpaka.hpp>
+
+    #include <stdio.h>              // printf
+    #include <math.h>               // ceil
+    #include <type_traits>          // std::is_same
+
+
+    class GemmAlpakaOmpNative
+    {
+    public:
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TAcc,
+            typename TElem>
+        ALPAKA_FN_ACC auto operator()(
+            TAcc const & acc,
+            TSize const & m, TSize const & n, TSize const & k,
+            TElem const & alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const & lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const & ldb,
+            TElem const & beta,
+            TElem * const MATMUL_RESTRICT C, TSize const & ldc) const
+        -> void
+        {
+            auto const gridThreadIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+            TSize const i(gridThreadIdx[0u]);
+            /*TSize const gThreadIdX(gridThreadIdx[1u]);
+            TSize const i = gThreadIdY * alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[1] + gThreadIdX;
+             * */
+
+            if(i>=n) return;
+
+            for(TSize j = 0; j < n; ++j)
+            {
+                C[i*ldc + j] *= beta;
+            }
+            for(TSize k2 = 0; k2 < k; ++k2)
+            {
+                TElem const a = alpha * A[i*lda + k2];
+
+                for(TSize j = 0; j < n; ++j)
+                {
+                    C[i*ldc + j] += a * B[k2*ldb + j];
+                }
+            }
+        }
+    };
+
+    namespace detail
+    {
+        //#############################################################################
+        //! The stream type trait for the stream that should be used for the given device.
+        //#############################################################################
+        template<
+            typename TDev,
+            typename TSfinae = void>
+        struct StreamType;
+
+        //#############################################################################
+        //! The stream type trait specialization for the CPU device.
+        //#############################################################################
+        template<>
+        struct StreamType<
+            alpaka::dev::DevCpu>
+        {
+#if (MATMUL_DEBUG >= MATMUL_DEBUG_FULL)
+            using type = alpaka::stream::StreamCpuSync;
+#else
+            using type = alpaka::stream::StreamCpuAsync;
+#endif
+        };
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && defined(__CUDACC__)
+        //#############################################################################
+        //! The stream type trait specialization for the CUDA device.
+        //#############################################################################
+        template<>
+        struct StreamType<
+            alpaka::dev::DevCudaRt>
+        {
+#if (MATMUL_DEBUG >= MATMUL_DEBUG_FULL)
+            using type = alpaka::stream::StreamCudaRtSync;
+#else
+            using type = alpaka::stream::StreamCudaRtAsync;
+#endif
+        };
+#endif
+    }
+    //#############################################################################
+    //! The stream type that should be used for the given device.
+    //#############################################################################
+    template<
+        typename TDev>
+    using Stream = typename detail::StreamType<TDev>::type;
+
+    //-----------------------------------------------------------------------------
+    //
+    //-----------------------------------------------------------------------------
+    template<
+        typename TAcc,
+        typename TKernelFnObj>
+    TReturn matmul_gemm_par_alpaka_ompNative(
+        TSize const m, TSize const n, TSize const k,
+        TElem const alpha,
+        TElem const * const MATMUL_RESTRICT A, TSize const lda,
+        TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+        TElem const beta,
+        TElem * const MATMUL_RESTRICT C, TSize const ldc)
+    {
+        using Dim1 = alpaka::dim::DimInt<1u>;
+        using Dim2 = alpaka::dim::DimInt<2u>;
+        using Dim3 = alpaka::dim::DimInt<3u>;
+
+        using Vec2 = alpaka::Vec<Dim2, TSize>;
+
+
+        if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+        {
+            MATMUL_TIME_RETURN_EARLY_OUT;
+        }
+
+        // Select a device to execute on.
+        alpaka::dev::Dev<TAcc> devAcc(
+            alpaka::dev::DevMan<TAcc>::getDevByIdx(0));
+
+        // Get a stream on this device.
+        Stream<alpaka::dev::Dev<TAcc>> stream(devAcc);
+
+        /* parallelize over the rows of the C matrix */
+        alpaka::Vec<Dim1, TSize> const v1uiHeightC(
+            m
+        );
+
+        alpaka::Vec<Dim1, TSize> const elemExtent(
+            static_cast<TSize>(1)
+        );
+
+        // Let alpaka calculate good block and grid sizes given our full problem extents.
+        alpaka::workdiv::WorkDivMembers<Dim1, TSize> const workDiv(
+            alpaka::workdiv::getValidWorkDiv<TAcc>(
+                devAcc,
+                v1uiHeightC,
+                elemExtent,
+                false,
+                alpaka::workdiv::GridBlockExtentSubDivRestrictions::EqualExtent));
+
+        TKernelFnObj kernel;
+
+        // Create the executor.
+        // NOTE: We remove the __restrict__ because alpaka calls std::ref on the arguments and std::ref errors.
+        // This is most probably undefined. MSVC compiles it without any warning.
+        auto const exec(alpaka::exec::create<TAcc>(
+            workDiv,
+            kernel,
+            m,
+            n,
+            k,
+            alpha,
+            reinterpret_cast<TElem const *>(A),
+            lda,
+            reinterpret_cast<TElem const *>(B),
+            ldb,
+            beta,
+            reinterpret_cast<TElem *>(C),
+            ldc));
+
+        MATMUL_TIME_START;
+
+        // Execute the kernel.
+        alpaka::stream::enqueue(stream, exec);
+
+        // Wait for the stream to finish the operations.
+        alpaka::wait::wait(stream);
+
+        MATMUL_TIME_END;
+        MATMUL_TIME_RETURN;
+    }
+
+    //-----------------------------------------------------------------------------
+    //
+    //-----------------------------------------------------------------------------
+    template<
+        typename TAcc,
+        typename TKernelFnObj>
+    TReturn matmul_gemm_par_alpaka_memcpy_ompNative(
+        TSize const m, TSize const n, TSize const k,
+        TElem const alpha,
+        TElem const * const MATMUL_RESTRICT A, TSize const lda,
+        TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+        TElem const beta,
+        TElem * const MATMUL_RESTRICT C, TSize const ldc)
+    {
+
+        using Dim1 = alpaka::dim::DimInt<1u>;
+        using Dim2 = alpaka::dim::DimInt<2u>;
+
+        if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+        {
+            MATMUL_TIME_RETURN_EARLY_OUT;
+        }
+
+        // Get the host device.
+        auto devHost(alpaka::dev::DevManCpu::getDevByIdx(0u));
+
+        // Select a device to execute on.
+        alpaka::dev::Dev<TAcc> devAcc(
+            alpaka::dev::DevMan<TAcc>::getDevByIdx(0));
+
+        // Get a stream on this device.
+        Stream<alpaka::dev::Dev<TAcc>> stream(devAcc);
+
+        alpaka::Vec<Dim2, TSize> const v2uiExtentsA(
+            m,
+            k);
+
+        alpaka::Vec<Dim2, TSize> const v2uiExtentsB(
+            k,
+            n);
+
+        // Result matrix is MxN. We create one worker per result matrix cell.
+        alpaka::Vec<Dim2, TSize> const v2uiExtentsC(
+            m,
+            n);
+
+        /* parallelize over the rows of the C matrix */
+        alpaka::Vec<Dim1, TSize> const v1uiHeightC(
+            m
+        );
+
+        alpaka::Vec<Dim1, TSize> const elemExtent(
+            static_cast<TSize>(1)
+        );
+
+        // Wrap the Pointers into memory buffer objects.
+        using BufWrapperIn = alpaka::mem::view::ViewPlainPtr<
+            std::decay<decltype(devHost)>::type,
+            TElem const,
+            alpaka::dim::DimInt<2u>,
+            TSize>;
+        BufWrapperIn bufAHost(A, devHost, v2uiExtentsA, lda * sizeof(TElem));
+        BufWrapperIn bufBHost(B, devHost, v2uiExtentsB, ldb * sizeof(TElem));
+        using BufWrapperOut = alpaka::mem::view::ViewPlainPtr<
+            std::decay<decltype(devHost)>::type,
+            TElem,
+            alpaka::dim::DimInt<2u>,
+            TSize>;
+        BufWrapperOut bufCHost(C, devHost, v2uiExtentsC, ldc * sizeof(TElem));
+
+        // Allocate the buffers on the accelerator and copy Host -> Acc.
+        // TODO: Test if interleaved is better then alloc first, copy later.
+        // Because alloc causes a device sync this may hinder the copies.
+        auto bufAAcc(alpaka::mem::buf::alloc<TElem, TSize>(devAcc, v2uiExtentsA));
+        alpaka::mem::view::copy(stream, bufAAcc, bufAHost, v2uiExtentsA);
+        auto bufBAcc(alpaka::mem::buf::alloc<TElem, TSize>(devAcc, v2uiExtentsB));
+        alpaka::mem::view::copy(stream, bufBAcc, bufBHost, v2uiExtentsB);
+        auto bufCAcc(alpaka::mem::buf::alloc<TElem, TSize>(devAcc, v2uiExtentsC));
+        alpaka::mem::view::copy(stream, bufCAcc, bufCHost, v2uiExtentsC);
+
+#ifdef MATMUL_RETURN_COMPUTATION_TIME
+        alpaka::wait::wait(stream);
+#endif
+
+        alpaka::Vec<Dim1, TSize> const M(m);
+        // Let alpaka calculate good block and grid sizes given our full problem extents.
+        alpaka::workdiv::WorkDivMembers<Dim1, TSize> const workDiv(
+            alpaka::workdiv::getValidWorkDiv<TAcc>(
+                devAcc,
+                v1uiHeightC,
+                elemExtent,
+                false,
+                alpaka::workdiv::GridBlockExtentSubDivRestrictions::EqualExtent));
+
+        // Create an instance of the kernel functor.
+        TKernelFnObj kernel;
+        // Create the executor.
+        // NOTE: We remove the __restrict__ because alpaka calls std::ref on the arguments and std::ref errors.
+        // This is most probably undefined. MSVC compiles it without any warning.
+        auto const exec(alpaka::exec::create<TAcc>(
+            workDiv,
+            kernel,
+            m,
+            n,
+            k,
+            alpha,
+            reinterpret_cast<TElem const *>(alpaka::mem::view::getPtrNative(bufAAcc)),
+            alpaka::mem::view::getPitchBytes<1>(bufAAcc)/sizeof(TElem),
+            reinterpret_cast<TElem const *>(alpaka::mem::view::getPtrNative(bufBAcc)),
+            alpaka::mem::view::getPitchBytes<1>(bufBAcc)/sizeof(TElem),
+            beta,
+            reinterpret_cast<TElem *>(alpaka::mem::view::getPtrNative(bufCAcc)),
+            alpaka::mem::view::getPitchBytes<1>(bufCAcc)/sizeof(TElem)));
+
+        alpaka::wait::wait(stream);
+        MATMUL_TIME_START;
+
+        // Execute the kernel.
+        alpaka::stream::enqueue(stream, exec);
+
+#ifdef MATMUL_RETURN_COMPUTATION_TIME
+        alpaka::wait::wait(stream);
+#endif
+        MATMUL_TIME_END;
+
+        // Copy back the result.
+        alpaka::mem::view::copy(stream, bufCHost, bufCAcc, v2uiExtentsC);
+
+        // Wait for the stream to finish the operations.
+        alpaka::wait::wait(stream);
+
+        MATMUL_TIME_RETURN;
+    }
+#endif

--- a/src/par/AlpakaOmpNative.cpp
+++ b/src/par/AlpakaOmpNative.cpp
@@ -1,0 +1,190 @@
+//-----------------------------------------------------------------------------
+//! \file
+//! Copyright 2013-2016 Benjamin Worpitz, Rene Widera
+//!
+//! This file is part of matmul.
+//!
+//! matmul is free software: you can redistribute it and/or modify
+//! it under the terms of the GNU Lesser General Public License as published by
+//! the Free Software Foundation, either version 3 of the License, or
+//! (at your option) any later version.
+//!
+//! matmul is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//! GNU Lesser General Public License for more details.
+//!
+//! You should have received a copy of the GNU Lesser General Public License
+//! along with matmul.
+//! If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+#if defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_SEQ) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_OMP2_T_SEQ) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_OMP2) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_BT_OMP4) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_THREADS) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_FIBERS)
+
+    #include <matmul/par/AlpakaOmpNative.h>
+
+    #include <matmul/par/AlpakaOmpNative.hpp>
+
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_SEQ
+        //-----------------------------------------------------------------------------
+        //
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_seq_alpaka_cpu_b_seq_t_seq_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc)
+        {
+            if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+            {
+                MATMUL_TIME_RETURN_EARLY_OUT;
+            }
+
+            return
+                matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccCpuSerial<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                    m, n, k,
+                    alpha,
+                    A, lda,
+                    B, ldb,
+                    beta,
+                    C, ldc);
+        }
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_OMP2_T_SEQ
+        //-----------------------------------------------------------------------------
+        //
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_b_omp2_t_seq_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc)
+        {
+            if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+            {
+                MATMUL_TIME_RETURN_EARLY_OUT;
+            }
+
+            return
+                matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccCpuOmp2Blocks<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                    m, n, k,
+                    alpha,
+                    A, lda,
+                    B, ldb,
+                    beta,
+                    C, ldc);
+        }
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_OMP2
+        //-----------------------------------------------------------------------------
+        //
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_b_seq_t_omp2_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc)
+        {
+            if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+            {
+                MATMUL_TIME_RETURN_EARLY_OUT;
+            }
+
+            return
+                matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccCpuOmp2Threads<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                    m, n, k,
+                    alpha,
+                    A, lda,
+                    B, ldb,
+                    beta,
+                    C, ldc);
+        }
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_BT_OMP4
+        //-----------------------------------------------------------------------------
+        //
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_bt_omp4_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc)
+        {
+            if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+            {
+                MATMUL_TIME_RETURN_EARLY_OUT;
+            }
+
+            return
+                matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccCpuOmp4<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                    m, n, k,
+                    alpha,
+                    A, lda,
+                    B, ldb,
+                    beta,
+                    C, ldc);
+        }
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_THREADS
+        //-----------------------------------------------------------------------------
+        //
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_par_alpaka_cpu_b_seq_t_threads_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc)
+        {
+            if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+            {
+                MATMUL_TIME_RETURN_EARLY_OUT;
+            }
+
+            return
+                matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccCpuThreads<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                    m, n, k,
+                    alpha,
+                    A, lda,
+                    B, ldb,
+                    beta,
+                    C, ldc);
+        }
+    #endif
+    #ifdef MATMUL_BUILD_PAR_ALPAKA_ACC_CPU_B_SEQ_T_FIBERS
+        //-----------------------------------------------------------------------------
+        //
+        //-----------------------------------------------------------------------------
+        TReturn matmul_gemm_seq_alpaka_cpu_b_seq_t_fibers_ompNative(
+            TSize const m, TSize const n, TSize const k,
+            TElem const alpha,
+            TElem const * const MATMUL_RESTRICT A, TSize const lda,
+            TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+            TElem const beta,
+            TElem * const MATMUL_RESTRICT C, TSize const ldc)
+        {
+            if(matmul_mat_gemm_early_out(m, n, k, alpha, beta))
+            {
+                MATMUL_TIME_RETURN_EARLY_OUT;
+            }
+
+            return
+                matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccCpuFibers<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                    m, n, k,
+                    alpha,
+                    A, lda,
+                    B, ldb,
+                    beta,
+                    C, ldc);
+        }
+    #endif
+#endif

--- a/src/par/AlpakaOmpNative.cu
+++ b/src/par/AlpakaOmpNative.cu
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------------
+//! \file
+//! Copyright 2013-2016 Benjamin Worpitz, Rene Widera
+//!
+//! This file is part of matmul.
+//!
+//! matmul is free software: you can redistribute it and/or modify
+//! it under the terms of the GNU Lesser General Public License as published by
+//! the Free Software Foundation, either version 3 of the License, or
+//! (at your option) any later version.
+//!
+//! matmul is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//! GNU Lesser General Public License for more details.
+//!
+//! You should have received a copy of the GNU Lesser General Public License
+//! along with matmul.
+//! If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+#if defined(MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA) || defined(MATMUL_BUILD_PAR_ALPAKA_ACC_GPU_CUDA_MEMCPY)
+
+    #include <matmul/par/AlpakaOmpNative.h>
+
+    #include <matmul/par/AlpakaOmpNative.hpp>
+
+    //-----------------------------------------------------------------------------
+    //
+    //-----------------------------------------------------------------------------
+    TReturn matmul_gemm_par_alpaka_gpu_cuda_ompNative(
+        TSize const m, TSize const n, TSize const k,
+        TElem const alpha,
+        TElem const * const MATMUL_RESTRICT A, TSize const lda,
+        TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+        TElem const beta,
+        TElem * const MATMUL_RESTRICT C, TSize const ldc)
+    {
+        return
+            matmul_gemm_par_alpaka_ompNative<alpaka::acc::AccGpuCudaRt<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                m, n, k,
+                alpha,
+                A, lda,
+                B, ldb,
+                beta,
+                C, ldc);
+    }
+    //-----------------------------------------------------------------------------
+    //
+    //-----------------------------------------------------------------------------
+    TReturn matmul_gemm_par_alpaka_gpu_cuda_memcpy_ompNative(
+        TSize const m, TSize const n, TSize const k,
+        TElem const alpha,
+        TElem const * const MATMUL_RESTRICT A, TSize const lda,
+        TElem const * const MATMUL_RESTRICT B, TSize const ldb,
+        TElem const beta,
+        TElem * const MATMUL_RESTRICT C, TSize const ldc)
+    {
+        return
+            matmul_gemm_par_alpaka_memcpy_ompNative<alpaka::acc::AccGpuCudaRt<alpaka::dim::DimInt<1u>, TSize>, GemmAlpakaOmpNative>(
+                m, n, k,
+                alpha,
+                A, lda,
+                B, ldb,
+                beta,
+                C, ldc);
+    }
+#endif


### PR DESCRIPTION
- add OpenMP alpaka kernel
- add interfaces to use the new kernel with alpaka
- `CMakeLists.txt`
  - add option `MATMUL_BENCHMARK_ALPAKA_CUDASDK_KERNEL` to enable
    the old sdk like kernel for alpaka
  - add option `MATMUL_BENCHMARK_ALPAKA_OMPNATIVE_KERNEL` to enable
    the new OpenMP alpaka kernel

This pull request contains the fix from #14

Tests:
- [x] Alpaka(CUDA) with verify results
- [x] Alpaka(OMP2) with verify results
